### PR TITLE
Tweaked syntax and improved type inference for the Traverse validator.

### DIFF
--- a/src/main/scala/com/stuartizon/validator/syntax/package.scala
+++ b/src/main/scala/com/stuartizon/validator/syntax/package.scala
@@ -1,0 +1,5 @@
+package com.stuartizon.validator
+
+package object syntax {
+  object traverseValidator extends TraverseValidatorSyntax
+}

--- a/src/main/scala/com/stuartizon/validator/syntax/traverseValidator.scala
+++ b/src/main/scala/com/stuartizon/validator/syntax/traverseValidator.scala
@@ -1,0 +1,53 @@
+package com.stuartizon.validator
+package syntax
+
+import cats.Traverse
+import cats.data.Validated._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import cats.syntax.traverse._
+
+import scala.language.{higherKinds, implicitConversions}
+
+trait TraverseValidatorSyntax {
+  implicit def syntaxTraverseValidator[A](validator: Validator[A]): TraverseValidatorOps[A] =
+    new TraverseValidatorOps[A](validator)
+
+  def validator[F[_] : Traverse]: TraverseAdhocValidatorOps[F] = new TraverseAdhocValidatorOps[F]
+}
+
+final class TraverseValidatorOps[A](validator: Validator[A]) {
+
+  /** Validates that all elements validate against the inner validator.
+    * Succeeds if the monad is empty.
+    */
+  def forEach[F[_] : Traverse]: Validator[F[A]] = (id: String, m: F[A]) =>
+    m.traverse[ValidationResult, A](validator.validate(id, _))
+
+  /** Validates that there is at least one element which validates against the inner validator.
+    * Fails if there are no such elements.
+    */
+  def contains[F[_] : Traverse]: Validator[F[A]] = (id: String, m: F[A]) => {
+    if (m.isEmpty) invalidNel(ErrorDescription(id, s"Must be non empty"))
+    else {
+      val v = m.map(validator.validate(id, _))
+      if (v.exists(_.isValid)) valid(m)
+      else v.sequence[ValidationResult, A]
+    }
+  }
+}
+
+final class TraverseAdhocValidatorOps[F[_] : Traverse] {
+  /** Validates that there is at least one element with the given value.
+    * Fails if there are no such elements.
+    *
+    * @param value value which the list must contain */
+  def contains[A](value: A): Validator[F[A]] = (id: String, m: F[A]) =>
+    if (m.exists(_ == value)) valid(m)
+    else invalidNel(ErrorDescription(id, s"Must contain $value"))
+
+  /** Validates that there is at least one element. Fails if there are no elements. */
+  def nonEmpty[A]: Validator[F[A]] = (id: String, m: F[A]) =>
+    if (m.nonEmpty) valid(m)
+    else invalidNel(ErrorDescription(id, s"Must be non empty"))
+}

--- a/src/test/scala/com/stuartizon/validator/TraverseValidatorSpec.scala
+++ b/src/test/scala/com/stuartizon/validator/TraverseValidatorSpec.scala
@@ -1,0 +1,139 @@
+package com.stuartizon.validator
+
+import cats.data.NonEmptyList
+import cats.data.Validated._
+import cats.instances.all._
+import com.stuartizon.validator.syntax.traverseValidator._
+import org.specs2.mutable.Specification
+
+class TraverseValidatorSpec extends Specification with ValidationMatchers {
+  val startsWithJ: Validator[String] = new Validator[String] {
+    override def validate(id: String, value: String): ValidationResult[String] =
+      if (value startsWith "J") valid(value)
+      else invalidNel(ErrorDescription(id, s"$value does not start with J"))
+  }
+
+  "forEach validator" should {
+
+    "validate a valid list" in {
+      val list = List("John", "Jack", "James")
+      startsWithJ.forEach[List].validate(list) must beSuccessful(list)
+    }
+
+    "validate an empty list" in {
+      val list: List[String] = Nil
+      startsWithJ.forEach[List].validate(list) must beSuccessful(list)
+    }
+
+    "fail for a list with one invalid element" in {
+      val list = List("John", "Jack", "Peter")
+      startsWithJ.forEach[List].validate(list) must beFailing(NonEmptyList.of(ErrorDescription("list", "Peter does not start with J")))
+    }
+
+    "fail for a list with multiple invalid elements" in {
+      val list = List("John", "Peter", "Simon")
+      startsWithJ.forEach[List].validate(list) must beFailing(NonEmptyList.of(ErrorDescription("list", "Peter does not start with J"), ErrorDescription("list", "Simon does not start with J")))
+    }
+
+    "validate a present optional" in {
+      val name = Some("John")
+      startsWithJ.forEach[Option].validate(name) must beSuccessful(name)
+    }
+
+    "validate a missing optional" in {
+      val name = None
+      startsWithJ.forEach[Option].validate(name) must beSuccessful(name)
+    }
+
+    "fail for an invalid optional" in {
+      val name = Some("Peter")
+      startsWithJ.forEach[Option].validate(name) must beFailing(NonEmptyList.of(ErrorDescription("name", "Peter does not start with J")))
+    }
+  }
+
+  "contains validator" should {
+    "validate a list with at least one valid element" in {
+      val list = List("John", "Peter")
+      startsWithJ.contains[List].validate(list) must beSuccessful(list)
+    }
+
+    "fail for a list with no valid elements" in {
+      val list = List("Peter", "Paul")
+      startsWithJ.contains[List].validate(list) must beFailing(NonEmptyList.of(ErrorDescription("list", "Peter does not start with J"), ErrorDescription("list", "Paul does not start with J")))
+    }
+
+    "fail for an empty list" in {
+      val list = Nil
+      startsWithJ.contains[List].validate(list) must beFailing(NonEmptyList.of(ErrorDescription("list", "Must be non empty")))
+    }
+
+    "validate a present optional" in {
+      val name = Some("John")
+      startsWithJ.contains[Option].validate(name) must beSuccessful(name)
+    }
+
+    "fail for an invalid optional" in {
+      val name = Some("Peter")
+      startsWithJ.contains[Option].validate(name) must beFailing(NonEmptyList.of(ErrorDescription("name", "Peter does not start with J")))
+    }
+
+    "fail for a missing optional" in {
+      val name = None
+      startsWithJ.contains[Option].validate(name) must beFailing(NonEmptyList.of(ErrorDescription("name", "Must be non empty")))
+    }
+  }
+
+  "contains value validator" should {
+    "validate a list containing the required element" in {
+      val list = List("John", "Peter", "Paul")
+      validator[List].contains("Paul").validate(list) must beSuccessful(list)
+    }
+
+    "fail for a list missing the required element" in {
+      val list = List("John", "Simon", "James")
+      validator[List].contains("Paul").validate(list) must beFailing(NonEmptyList.of(ErrorDescription("list", "Must contain Paul")))
+    }
+
+    "fail for an empty list" in {
+      val list = Nil
+      validator[List].contains("Paul").validate(list) must beFailing(NonEmptyList.of(ErrorDescription("list", "Must contain Paul")))
+    }
+
+    "validate a present optional" in {
+      val name = Some("John")
+      validator[Option].contains("John").validate(name) must beSuccessful(name)
+    }
+
+    "fail for an invalid optional" in {
+      val name = Some("Peter")
+      validator[Option].contains("John").validate(name) must beFailing(NonEmptyList.of(ErrorDescription("name", "Must contain John")))
+    }
+
+    "fail for a missing optional" in {
+      val name = None
+      validator[Option].contains("Paul").validate(name) must beFailing(NonEmptyList.of(ErrorDescription("name", "Must contain Paul")))
+    }
+  }
+
+  "nonEmpty validator" should {
+    "validate a list" in {
+      val list = List(2)
+      validator[List].nonEmpty.validate(list) must beSuccessful(list)
+    }
+
+    "fail for an empty list" in {
+      val list = Nil
+      validator[List].nonEmpty.validate(list) must beFailing(NonEmptyList.of(ErrorDescription("list", "Must be non empty")))
+    }
+
+    "validate a present optional" in {
+      val name = Some("")
+      validator[Option].nonEmpty.validate(name) must beSuccessful(name)
+    }
+
+    "fail for a missing optional" in {
+      val name = None
+      validator[Option].nonEmpty.validate(name) must beFailing(NonEmptyList.of(ErrorDescription("name", "Must be non empty")))
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a slightly different approach to how one can use the Traverse validator:

- the syntax is now a little bit more concise, starting with the validator which allows you to infer the inner type:
   ```scala
   startsWithJ.forEach[List].validate(list)
   ```
    instead of
   ```scala
   forEach[List, String](startsWithJ).validate(list)
   ```
- in a case of `contains` and `nonEmpty` functions which don't need an inner validator, you can use the `validator[F]` which will bring those functions into the scope, e.g.:
    ```scala
   validator[List].contains("Paul").validate(list)
   ```
    instead of
   ```scala
   contains[List, String]("Paul").validate(list)
   ```
   (that's a tiny bit longer than your version, but it makes it consistent with the inner type infered automatically)

- There is no need to extend the validator anymore since the syntax can be imported in a similar way to how it's done in cats for both `syntax` and `instances` - just bring it into the scope whenever it's needed, e.g.:
   ```scala
   import com.stuartizon.validator.syntax.traverseValidator._
   ```

I did have a go at turning the syntax inside out to start with the traversable instance and chaining it with the validation like so `list.forEach(startsWithJ).validate` which gets rid of the explicit types and makes the syntax even more concise, but this approach requires some changes to the macros to prevent the name of the traversable instance from being lost.